### PR TITLE
Don't "cd" to directory, use cwd in exec

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,9 @@ Elixir.extend('elm', (dir) => {
 
         let deferred = Q.defer();
 
-        return exec(`cd ${elmPath}; ${command}`, (err, stdout, stderr) => {
+        return exec(`${command}`, {
+            cwd: elmPath,
+        }, (err, stdout, stderr) => {
             console.log(stdout);
             console.log(stderr);
 


### PR DESCRIPTION
The process separator `;` doesn't work on Windows. Better to use the options for exec for the current working directory, this way you don't need to `cd` to it.